### PR TITLE
fix: make target-os cfg in Cargo.toml match sys/mod.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1.0.0"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 ioctl-sys = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
The Linux and Android implementations use an extra dependency that mac and iOS don't depend on. This dependency was accidentally disabled in Cargo.toml for Android builds. This should fix #16.