### PR TITLE
Optimization: Rm dep `libc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,6 @@ version = "0.1.7"
 dependencies = [
  "cfg-if",
  "ioctl-sys",
- "libc",
  "tempfile",
  "tracing",
  "tracing-attributes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ cfg-if = "1.0.0"
 tracing = { version = "0.1.37", default-features = false, optional = true }
 tracing-attributes = { version = "0.1.26", optional = true }
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 ioctl-sys = "0.8.0"
 

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -1,9 +1,14 @@
-use std::{convert::TryInto, fs, io, mem::size_of, os::unix::io::AsRawFd, path::Path};
+use std::{
+    convert::TryInto,
+    fs, io,
+    mem::size_of,
+    os::{raw::c_int, unix::io::AsRawFd},
+    path::Path,
+};
 
-use ioctl_sys::iow;
-use libc::c_int;
+use ioctl_sys::{ioctl, iow};
 
-use super::super::utility::AutoRemovedFile;
+use crate::sys::utility::AutoRemovedFile;
 
 const C_INT_SIZE: usize = size_of::<c_int>();
 const FICLONE: u32 = iow!(0x94, 9, C_INT_SIZE);
@@ -16,7 +21,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
 
     let ret = unsafe {
         // http://man7.org/linux/man-pages/man2/ioctl_ficlonerange.2.html
-        libc::ioctl(
+        ioctl(
             dest.as_raw_fd(),
             FICLONE.try_into().unwrap(),
             src.as_raw_fd(),

--- a/src/sys/unix/macos.rs
+++ b/src/sys/unix/macos.rs
@@ -1,21 +1,25 @@
-use std::{ffi::CString, io, os::unix::ffi::OsStrExt, path::Path};
+use std::{
+    ffi::CString,
+    io,
+    os::{
+        raw::{c_char, c_int},
+        unix::ffi::OsStrExt,
+    },
+    path::Path,
+};
 
 fn cstr(path: &Path) -> io::Result<CString> {
     Ok(CString::new(path.as_os_str().as_bytes())?)
 }
 
-// const CLONE_NOFOLLOW: libc::c_int = 0x0001;
-const CLONE_NOOWNERCOPY: libc::c_int = 0x0002;
+// const CLONE_NOFOLLOW: c_int = 0x0001;
+const CLONE_NOOWNERCOPY: c_int = 0x0002;
 
 extern "C" {
     // http://www.manpagez.com/man/2/clonefileat/
     // https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/sys/clonefile.h
     // TODO We need weak linkage here (OSX > 10.12, iOS > 10.0), otherwise compilation will fail on older versions
-    fn clonefile(
-        src: *const libc::c_char,
-        dest: *const libc::c_char,
-        flags: libc::c_int,
-    ) -> libc::c_int;
+    fn clonefile(src: *const c_char, dest: *const c_char, flags: c_int) -> c_int;
 }
 
 pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {


### PR DESCRIPTION
On MacOS, all `reflink` uses is just `c_int` and `c_char` and that can be imported from `std::os::raw`.

On Linux, `ioctl_sys` provides the `ioctl` function and `c_int` can be imported from `std::os::raw`, so there's no need for dep `libc`.