### PR TITLE
avoid hitting the filesystem unless there's an actual error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,7 @@ use std::path::Path;
 pub fn reflink(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
     #[cfg_attr(feature = "tracing", tracing_attributes::instrument(name = "reflink"))]
     fn inner(from: &Path, to: &Path) -> io::Result<()> {
-        if !from.is_file() {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "the source path is not an existing regular file",
-            ))
-        } else {
-            sys::reflink(from, to)
-        }
+        sys::reflink(from, to).map_err(|err| check_is_file_and_error(from, err))
     }
 
     inner(from.as_ref(), to.as_ref())
@@ -92,20 +85,28 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
         tracing_attributes::instrument(name = "reflink_or_copy")
     )]
     fn inner(from: &Path, to: &Path) -> io::Result<Option<u64>> {
-        if !from.is_file() {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "the source path is not an existing regular file",
-            ))
-        } else if let Err(_err) = sys::reflink(from, to) {
+        if let Err(_err) = sys::reflink(from, to) {
             #[cfg(feature = "tracing")]
             tracing::warn!(?_err, "Failed to reflink, fallback to fs::copy");
 
-            fs::copy(from, to).map(Some)
+            fs::copy(from, to)
+                .map(Some)
+                .map_err(|err| check_is_file_and_error(from, err))
         } else {
             Ok(None)
         }
     }
 
     inner(from.as_ref(), to.as_ref())
+}
+
+fn check_is_file_and_error(from: &Path, err: io::Error) -> io::Error {
+    if from.is_file() {
+        err
+    } else {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the source path is not an existing regular file",
+        )
+    }
 }


### PR DESCRIPTION
In high-perf situations, every fs operation counts. Doing this .is_file() check on the happy path unconditionally can cause noticeable perf issues.

Testing on orogene, the difference is very variable. This `.is_file()` call accounts for a whole 7.75% of items on a flamegraph, out of the 72.68% that `reflink_or_copy` takes up--so roughly 10% of the total cost of reflinking is spent on this one paranoid check.

Instead of removing it altogether, I hope it's acceptable to just defer the check for the sake of retaining the same error message, and just reflinking optimistically.