### PR TITLE
Port code to use rustix instead of ioctl-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,12 +54,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "ioctl-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
-
-[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +100,10 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "cfg-if",
- "ioctl-sys",
+ "rustix",
  "tempfile",
  "tracing",
  "tracing-attributes",
@@ -118,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.15"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
  "bitflags 2.4.0",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ cfg-if = "1.0.0"
 tracing = { version = "0.1.37", default-features = false, optional = true }
 tracing-attributes = { version = "0.1.26", optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-ioctl-sys = "0.8.0"
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies.rustix]
+version = "0.38.20"
+default-features = false
+features = ["fs", "std"]
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.51.1", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Ioctl", "Win32_System_IO", "Win32_System_SystemServices"] }

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs, io,
-    path::Path,
-};
+use std::{fs, io, path::Path};
 
 use crate::sys::utility::AutoRemovedFile;
 
@@ -10,10 +7,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
 
     // pass O_EXCL to mimic macos behaviour
     let dest = AutoRemovedFile::create_new(to)?;
-    rustix::fs::ioctl_ficlone(
-        &dest,
-        &src
-    )?;
+    rustix::fs::ioctl_ficlone(&dest, &src)?;
 
     dest.persist();
     Ok(())

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -1,37 +1,20 @@
 use std::{
-    convert::TryInto,
     fs, io,
-    mem::size_of,
-    os::{raw::c_int, unix::io::AsRawFd},
     path::Path,
 };
 
-use ioctl_sys::{ioctl, iow};
-
 use crate::sys::utility::AutoRemovedFile;
-
-const C_INT_SIZE: usize = size_of::<c_int>();
-const FICLONE: u32 = iow!(0x94, 9, C_INT_SIZE);
 
 pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
     let src = fs::File::open(from)?;
 
     // pass O_EXCL to mimic macos behaviour
     let dest = AutoRemovedFile::create_new(to)?;
+    rustix::fs::ioctl_ficlone(
+        &dest,
+        &src
+    )?;
 
-    let ret = unsafe {
-        // http://man7.org/linux/man-pages/man2/ioctl_ficlonerange.2.html
-        ioctl(
-            dest.as_raw_fd(),
-            FICLONE.try_into().unwrap(),
-            src.as_raw_fd(),
-        )
-    };
-
-    if ret == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        dest.persist();
-        Ok(())
-    }
+    dest.persist();
+    Ok(())
 }

--- a/src/sys/utility.rs
+++ b/src/sys/utility.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::os::unix::io::{AsFd, BorrowedFd, AsRawFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 #[derive(Debug)]
 pub(super) struct AutoRemovedFile {

--- a/src/sys/utility.rs
+++ b/src/sys/utility.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsFd, BorrowedFd, AsRawFd, RawFd};
 
 #[derive(Debug)]
 pub(super) struct AutoRemovedFile {
@@ -38,6 +38,13 @@ impl AutoRemovedFile {
 
     pub fn as_inner_file(&self) -> &File {
         self.inner.as_ref().unwrap()
+    }
+}
+
+#[cfg(unix)]
+impl AsFd for AutoRemovedFile {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.as_inner_file().as_fd()
     }
 }
 


### PR DESCRIPTION
This commit replaces the code using ioctl-sys with equivalent code using rustix. In addition to safety, this move also removes the dependency on C code and replaces it with a syscall, which is much faster.

This only applies for Linux, as macOS's "clonefile" call has not been ported to rustix yet.