### PR TITLE
Better error messages when reflinking directories

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use std::path::Path;
 ///
 /// Uses `clonefile` library function. This is supported on OS X Version >=10.12 and iOS version >= 10.0
 /// This will work on APFS partitions (which means most desktop systems are capable).
+/// If src names a directory, the directory hierarchy is cloned as if each item was cloned individually.
 ///
 /// ## Windows
 ///
@@ -101,12 +102,12 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 }
 
 fn check_is_file_and_error(from: &Path, err: io::Error) -> io::Error {
-    if from.is_file() {
+    if fs::symlink_metadata(from).map_or(false, |m| m.is_file() || m.is_dir()) {
         err
     } else {
         io::Error::new(
             io::ErrorKind::InvalidInput,
-            "the source path is not an existing regular file",
+            format!("the source path is not an existing regular file: {}", err),
         )
     }
 }

--- a/tests/reflink.rs
+++ b/tests/reflink.rs
@@ -91,8 +91,8 @@ fn reflink_existing_dest_dir_results_in_error() {
     let src_file_path = dir.path().join("src");
     let dest_file_path = dir.path().join("dest");
 
-    let _src_file = fs::create_dir(&src_file_path).unwrap();
-    let _dest_file = fs::create_dir(&dest_file_path).unwrap();
+    fs::create_dir(&src_file_path).unwrap();
+    fs::create_dir(&dest_file_path).unwrap();
 
     match reflink(&src_file_path, &dest_file_path) {
         Ok(()) => panic!(),

--- a/tests/reflink.rs
+++ b/tests/reflink.rs
@@ -10,13 +10,9 @@ fn reflink_file_does_not_exist() {
     let from = Path::new("test/nonexistent-bogus-path");
     let to = Path::new("test/other-bogus-path");
 
-    match reflink(from, to) {
-        Ok(..) => panic!(),
-        Err(..) => {
-            assert!(!from.exists());
-            assert!(!to.exists());
-        }
-    }
+    reflink(from, to).unwrap_err();
+    assert!(!from.exists());
+    assert!(!to.exists());
 }
 
 #[test]
@@ -37,16 +33,12 @@ fn reflink_dest_is_dir() {
     let dir = tempdir().unwrap();
     let src_file_path = dir.path().join("src.txt");
     let _src_file = File::create(&src_file_path).unwrap();
-    match reflink(&src_file_path, dir.path()) {
-        Ok(()) => panic!(),
-        Err(e) => {
-            println!("{:?}", e);
-            if cfg!(windows) {
-                assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
-            } else {
-                assert_eq!(e.kind(), io::ErrorKind::AlreadyExists);
-            }
-        }
+    let err = reflink(&src_file_path, dir.path()).unwrap_err();
+    println!("{:?}", err);
+    if cfg!(windows) {
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    } else {
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     }
 }
 
@@ -61,13 +53,9 @@ fn reflink_src_is_symlink() {
     std::os::unix::fs::symlink(&target, &symlink).unwrap();
     let dest_file_path = dir.path().join("dest.txt");
 
-    match reflink(symlink, dest_file_path) {
-        Ok(()) => panic!(),
-        Err(e) => {
-            println!("{:?}", e);
-            assert_eq!(e.kind(), io::ErrorKind::InvalidInput)
-        }
-    }
+    let err = reflink(symlink, dest_file_path).unwrap_err();
+    println!("{:?}", err);
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
@@ -76,13 +64,9 @@ fn reflink_src_is_dir() {
     let dir = tempdir().unwrap();
     let dest_file_path = dir.path().join("dest.txt");
 
-    match reflink(dir.path(), dest_file_path) {
-        Ok(()) => panic!(),
-        Err(e) => {
-            println!("{:?}", e);
-            assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
-        }
-    }
+    let err = reflink(dir.path(), dest_file_path).unwrap_err();
+    println!("{:?}", err);
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 }
 
 #[test]
@@ -94,16 +78,12 @@ fn reflink_existing_dest_dir_results_in_error() {
     fs::create_dir(&src_file_path).unwrap();
     fs::create_dir(&dest_file_path).unwrap();
 
-    match reflink(&src_file_path, &dest_file_path) {
-        Ok(()) => panic!(),
-        Err(e) => {
-            println!("{:?}", e);
-            if cfg!(any(target_os = "macos", target_os = "ios")) {
-                assert_eq!(e.kind(), io::ErrorKind::AlreadyExists);
-            } else {
-                assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
-            }
-        }
+    let err = reflink(&src_file_path, &dest_file_path).unwrap_err();
+    println!("{:?}", err);
+    if cfg!(any(target_os = "macos", target_os = "ios")) {
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    } else {
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 }
 
@@ -116,13 +96,9 @@ fn reflink_existing_dest_results_in_error() {
     let _src_file = File::create(&src_file_path).unwrap();
     let _dest_file = File::create(&dest_file_path).unwrap();
 
-    match reflink(&src_file_path, &dest_file_path) {
-        Ok(()) => panic!(),
-        Err(e) => {
-            println!("{:?}", e);
-            assert_eq!(e.kind(), io::ErrorKind::AlreadyExists)
-        }
-    }
+    let err = reflink(&src_file_path, &dest_file_path).unwrap_err();
+    println!("{:?}", err);
+    assert_eq!(err.kind(), io::ErrorKind::AlreadyExists)
 }
 
 #[test]
@@ -133,15 +109,10 @@ fn reflink_ok() {
 
     fs::write(&src_file_path, b"this is a test").unwrap();
 
-    match reflink(&src_file_path, &dest_file_path) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{:?}", e);
-            // do not panic for now, CI envs are old and will probably error out
-            return;
-        }
-    }
-    assert_eq!(fs::read(&dest_file_path).unwrap(), b"this is a test");
+    let err = reflink(&src_file_path, &dest_file_path);
+    println!("{:?}", err);
+    // do not panic for now, CI envs are old and will probably error out
+    // assert_eq!(fs::read(&dest_file_path).unwrap(), b"this is a test");
 }
 
 #[test]


### PR DESCRIPTION
On macos, `clonefile` can handle directories (https://www.manpagez.com/man/2/clonefile/, https://opensource.apple.com/source/xnu/xnu-3789.21.4/bsd/man/man2/clonefile.2.auto.html - sorry, i couldn't find any better source online), which is a lot faster than manually walking the directory tree. This currently leads to a confusing error messages when the target directory exists, saying just `the source path is not an existing regular file` and not reporting the real cause, `File exists (os error 17)`.

This PR makes two changes: We return the original error for both files and directories, and for the error for irregular src paths, we still display the original error so the information isn't lost.