### PR TITLE
Fail reflink_or_copy if target file already exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+
+# JetBrains
+/.idea

--- a/examples/clone_or_copy.rs
+++ b/examples/clone_or_copy.rs
@@ -9,6 +9,10 @@ fn main() -> std::io::Result<()>{
     let src_file = &args[1];
     let tgt_file = &args[2];
 
-    let _ = reflink_copy::reflink_or_copy(src_file, tgt_file)?;
+    let result = reflink_copy::reflink_or_copy(src_file, tgt_file)?;
+    match result {
+        Some(_) => println!("File has been copied"),
+        None => println!("File has been cloned"),
+    }
     Ok(())
 }

--- a/examples/clone_or_copy.rs
+++ b/examples/clone_or_copy.rs
@@ -1,0 +1,14 @@
+// cargo run --example clone_or_copy V:\file.bin V:\file-clone.bin
+
+fn main() -> std::io::Result<()>{
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <source_file> <target_file>", args[0]);
+        return Ok(());
+    }
+    let src_file = &args[1];
+    let tgt_file = &args[2];
+
+    let _ = reflink_copy::reflink_or_copy(src_file, tgt_file)?;
+    Ok(())
+}

--- a/examples/clone_or_copy.rs
+++ b/examples/clone_or_copy.rs
@@ -1,6 +1,6 @@
 // cargo run --example clone_or_copy V:\file.bin V:\file-clone.bin
 
-fn main() -> std::io::Result<()>{
+fn main() -> std::io::Result<()> {
     let args: Vec<_> = std::env::args().collect();
     if args.len() < 3 {
         eprintln!("Usage: {} <source_file> <target_file>", args[0]);

--- a/examples/clonefile.rs
+++ b/examples/clonefile.rs
@@ -1,6 +1,6 @@
 // cargo run --example clonefile V:\file.bin V:\file-clone.bin
 
-fn main() -> std::io::Result<()>{
+fn main() -> std::io::Result<()> {
     let args: Vec<_> = std::env::args().collect();
     if args.len() < 3 {
         eprintln!("Usage: {} <source_file> <target_file>", args[0]);

--- a/examples/clonefile.rs
+++ b/examples/clonefile.rs
@@ -1,0 +1,13 @@
+// cargo run --example clonefile V:\file.bin V:\file-clone.bin
+
+fn main() -> std::io::Result<()>{
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <source_file> <target_file>", args[0]);
+        return Ok(());
+    }
+    let src_file = &args[1];
+    let tgt_file = &args[2];
+
+    reflink_copy::reflink(src_file, tgt_file)
+}


### PR DESCRIPTION
This might be a controversial take, so I decided to create a separate PR.

The reflink function fails if the target file exists, whereas reflink_or_copy switches to copying. As a result, instead of saving space when possible, the function creates a full copy. I see two solutions for this problem:
- Make reflink_or_copy act like reflink and return an error if the target file exists.
- Rewrite the function to clone blocks even if the target file exists.

This PR implements the first solution, making reflink_or_copy return an error if the target file exists. I also added a few other unrecoverable errors to the list.