### PR TITLE
Implement check_reflink_support for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,43 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
+    - name: Setup Dev-Drive ReFS1
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: samypr100/setup-dev-drive@v3
+      with:
+        drive-size: 1GB
+        drive-format: ReFS
+        drive-type: Dynamic
+        drive-path: "${{ runner.temp }}/dev-drives/refs1.vhdx"
+        mount-path: "${{ runner.temp }}/dev-drives/refs1"
+
+    - name: Setup Dev-Drive ReFS2
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: samypr100/setup-dev-drive@v3
+      with:
+        drive-size: 1GB
+        drive-format: ReFS
+        drive-type: Dynamic
+        drive-path: "${{ runner.temp }}/dev-drives/refs2.vhdx"
+        mount-path: "${{ runner.temp }}/dev-drives/refs2"
+
+    - name: Setup Dev-Drive NTFS
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: samypr100/setup-dev-drive@v3
+      with:
+        drive-size: 1GB
+        drive-format: NTFS
+        drive-type: Dynamic
+        drive-path: "${{ runner.temp }}/dev-drives/ntfs.vhdx"
+        mount-path: "${{ runner.temp }}/dev-drives/ntfs"
+
     - name: Test
       if: "! matrix.use-cross"
-      run: cargo test --target ${{ matrix.target }}
+      run: cargo test --target ${{ matrix.target }} -- --ignored
 
     - name: Test using cross
       if: "matrix.use-cross"
-      run: cross test --target ${{ matrix.target }}
+      run: cross test --target ${{ matrix.target }} -- --ignored
 
   cross-check:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +52,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,12 +92,42 @@ name = "reflink-copy"
 version = "0.1.19"
 dependencies = [
  "cfg-if",
+ "regex",
  "rustix",
  "tempfile",
  "tracing",
  "tracing-attributes",
  "windows",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-attributes",
+ "walkdir",
  "windows",
 ]
 
@@ -140,6 +141,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -199,6 +209,25 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ tracing = ["dep:tracing", "dep:tracing-attributes"]
 
 [dev-dependencies]
 tempfile = "3.12.0"
+regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tracing = ["dep:tracing", "dep:tracing-attributes"]
 [dev-dependencies]
 tempfile = "3.12.0"
 regex = "1.11.1"
+walkdir = "2.5.0"

--- a/examples/check_reflink_support.rs
+++ b/examples/check_reflink_support.rs
@@ -1,0 +1,15 @@
+// cargo run --example check_reflink_support V:\folder1 X:\folder2
+
+fn main() -> std::io::Result<()> {
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <source_path> <target_path>", args[0]);
+        return Ok(());
+    }
+    let src_path = &args[1];
+    let tgt_path = &args[2];
+
+    let result = reflink_copy::check_reflink_support(src_path, tgt_path)?;
+    println!("{result:?}");
+    Ok(())
+}

--- a/examples/copy_folder.rs
+++ b/examples/copy_folder.rs
@@ -1,0 +1,56 @@
+use reflink_copy::ReflinkSupport;
+use std::fs;
+use std::io;
+use std::path::Path;
+use walkdir::WalkDir;
+
+// cargo run --example copy_folder V:/1 V:/2
+
+fn main() -> io::Result<()> {
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <source_folder> <target_folder>", args[0]);
+        return Ok(());
+    }
+
+    let from = Path::new(&args[1]);
+    let to = Path::new(&args[2]);
+    let reflink_support = reflink_copy::check_reflink_support(from, to)?;
+    println!("Reflink support: {reflink_support:?}");
+
+    let mut reflinked_count = 0u64;
+    let mut copied_count = 0u64;
+
+    for entry in WalkDir::new(from) {
+        let entry = entry?;
+        let relative_path = entry.path().strip_prefix(from).unwrap();
+        let target_path = to.join(relative_path);
+
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(&target_path)?;
+        } else {
+            match reflink_support {
+                ReflinkSupport::Supported => {
+                    reflink_copy::reflink(entry.path(), target_path)?;
+                    reflinked_count = reflinked_count.saturating_add(1);
+                }
+                ReflinkSupport::Unknown => {
+                    let result = reflink_copy::reflink_or_copy(entry.path(), target_path)?;
+                    if result.is_some() {
+                        copied_count = copied_count.saturating_add(1);
+                    } else {
+                        reflinked_count = reflinked_count.saturating_add(1);
+                    }
+                }
+                ReflinkSupport::NotSupported => {
+                    fs::copy(entry.path(), target_path)?;
+                    copied_count = copied_count.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    println!("reflinked files count: {reflinked_count}");
+    println!("copied files count: {copied_count}");
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,18 +155,17 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 /// reflink.
 ///
 /// > Note: Currently the function works only for windows. It returns `Ok(ReflinkSupport::Unknown)`
-/// for any other platform.
+/// > for any other platform.
 ///
 /// # Example
 /// ```
 /// let support = reflink_copy::check_reflink_support("C:\\path\\to\\file", "C:\\path\\to\\another_file")?;
 /// let support = reflink_copy::check_reflink_support("path\\to\\folder", "path\\to\\another_folder")?;
 /// ```
-pub fn check_reflink_support<P, Q>(from: P, to: Q) -> io::Result<ReflinkSupport>
-where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
-{
+pub fn check_reflink_support(
+    from: impl AsRef<Path>,
+    to: impl AsRef<Path>,
+) -> io::Result<ReflinkSupport> {
     if cfg!(target_os = "windows") {
         sys::check_reflink_support(from, to)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,13 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 ///
 /// # Example
 /// ```
-/// let support = reflink_copy::check_reflink_support("C:\\path\\to\\file", "C:\\path\\to\\another_file")?;
-/// let support = reflink_copy::check_reflink_support("path\\to\\folder", "path\\to\\another_folder")?;
+/// fn main() -> std::io::Result<()> {
+///     let support = reflink_copy::check_reflink_support("C:\\path\\to\\file", "C:\\path\\to\\another_file")?;
+///     println!("{support:?}");
+///     let support = reflink_copy::check_reflink_support("path\\to\\folder", "path\\to\\another_folder")?;
+///     println!("{support:?}");
+///     Ok(())
+/// }
 /// ```
 pub fn check_reflink_support(
     from: impl AsRef<Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,19 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 
     inner(from.as_ref(), to.as_ref())
 }
-
+/// Checks whether reflink is supported on the filesystem for the specified source and target paths.
+///
+/// This function verifies that both paths are on the same volume and that the filesystem supports
+/// reflink.
+///
+/// > Note: Currently the function works only for windows. It returns `Ok(ReflinkSupport::Unknown)`
+/// for any other platform.
+///
+/// # Example
+/// ```
+/// let support = reflink_copy::check_reflink_support("C:\\path\\to\\file", "C:\\path\\to\\another_file")?;
+/// let support = reflink_copy::check_reflink_support("path\\to\\folder", "path\\to\\another_folder")?;
+/// ```
 pub fn check_reflink_support<P, Q>(from: P, to: Q) -> io::Result<ReflinkSupport>
 where
     P: AsRef<Path>,
@@ -162,8 +174,13 @@ where
     }
 }
 
+/// Enum indicating the reflink support status.
+#[derive(Debug, PartialEq)]
 pub enum ReflinkSupport {
+    /// Reflink is supported.
     Supported,
+    /// Reflink is not supported.
     NotSupported,
+    /// Reflink support is unconfirmed.
     Unknown,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,11 +166,10 @@ pub fn check_reflink_support(
     from: impl AsRef<Path>,
     to: impl AsRef<Path>,
 ) -> io::Result<ReflinkSupport> {
-    if cfg!(target_os = "windows") {
-        sys::check_reflink_support(from, to)
-    } else {
-        Ok(ReflinkSupport::Unknown)
-    }
+    #[cfg(windows)]
+    return sys::check_reflink_support(from, to);
+    #[cfg(not(windows))]
+    Ok(ReflinkSupport::Unknown)
 }
 
 /// Enum indicating the reflink support status.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,3 +149,21 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 
     inner(from.as_ref(), to.as_ref())
 }
+
+pub fn check_reflink_support<P, Q>(from: P, to: Q) -> io::Result<ReflinkSupport>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+{
+    if cfg!(target_os = "windows") {
+        sys::check_reflink_support(from, to)
+    } else {
+        Ok(ReflinkSupport::Unknown)
+    }
+}
+
+pub enum ReflinkSupport {
+    Supported,
+    NotSupported,
+    Unknown,
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -11,6 +11,7 @@ cfg_if! {
     } else if #[cfg(windows)] {
         mod windows_impl;
         pub use self::windows_impl::reflink;
+        pub use self::windows_impl::check_reflink_support;
     } else {
         pub use self::reflink_not_supported as reflink;
     }

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -302,14 +302,17 @@ pub fn check_reflink_support(
     from: impl AsRef<Path>,
     to: impl AsRef<Path>,
 ) -> io::Result<ReflinkSupport> {
-    let from = get_volume_path(from)?;
-    let to = get_volume_path(to)?;
+    let from_volume = get_volume_path(from)?;
+    let to_volume = get_volume_path(to)?;
 
-    if from != to {
+    let from = String::from_utf16(&from_volume).map_err(io::Error::other)?;
+    let to = String::from_utf16(&to_volume).map_err(io::Error::other)?;
+
+    if from.to_uppercase() != to.to_uppercase() {
         return Ok(ReflinkSupport::NotSupported);
     }
 
-    let volume_flags = get_volume_flags(&from)?;
+    let volume_flags = get_volume_flags(&from_volume)?;
     if volume_flags & FILE_SUPPORTS_BLOCK_REFCOUNTING == FILE_SUPPORTS_BLOCK_REFCOUNTING {
         Ok(ReflinkSupport::Supported)
     } else {

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -378,7 +378,6 @@ fn get_volume_flags(volume_path_w: &Vec<u16>) -> io::Result<u32> {
     Ok(file_system_flags)
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -345,7 +345,7 @@ fn get_volume_path(path: impl AsRef<Path>) -> io::Result<Vec<u16>> {
 /// [GetVolumeNameForVolumeMountPointW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumenameforvolumemountpointw)
 /// that retrieves a volume GUID path for the volume that is associated with the specified volume
 /// mount point (drive letter, volume GUID path, or mounted folder).
-fn get_volume_guid_path(volume_path_w: &Vec<u16>) -> io::Result<Vec<u16>> {
+fn get_volume_guid_path(volume_path_w: &[u16]) -> io::Result<Vec<u16>> {
     let mut volume_guid_path = vec![0u16; 50usize];
     unsafe {
         GetVolumeNameForVolumeMountPointW(PCWSTR(volume_path_w.as_ptr()), volume_guid_path.as_mut())
@@ -361,7 +361,7 @@ fn get_volume_guid_path(volume_path_w: &Vec<u16>) -> io::Result<Vec<u16>> {
 /// A wrapper function for
 /// [GetVolumeInformationW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw)
 /// that returns `FileSystemFlags`.
-fn get_volume_flags(volume_path_w: &Vec<u16>) -> io::Result<u32> {
+fn get_volume_flags(volume_path_w: &[u16]) -> io::Result<u32> {
     let mut file_system_flags = 0u32;
 
     unsafe {

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -308,6 +308,7 @@ pub fn check_reflink_support(
     let from_guid = get_volume_guid_path(&from_volume)?;
     let to_guid = get_volume_guid_path(&to_volume)?;
     if from_guid != to_guid {
+        // The source and destination files must be on the same volume
         return Ok(ReflinkSupport::NotSupported);
     }
 

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -343,7 +343,7 @@ fn get_volume_path(path: impl AsRef<Path>) -> io::Result<Vec<u16>> {
 
 /// A wrapper function for
 /// [GetVolumeNameForVolumeMountPointW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumenameforvolumemountpointw)
-/// that retrieves  a volume GUID path for the volume that is associated with the specified volume
+/// that retrieves a volume GUID path for the volume that is associated with the specified volume
 /// mount point (drive letter, volume GUID path, or mounted folder).
 fn get_volume_guid_path(volume_path_w: &Vec<u16>) -> io::Result<Vec<u16>> {
     let mut volume_guid_path = vec![0u16; 50usize];

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -383,6 +383,15 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_get_volume_path_is_same() -> io::Result<()> {
+        let src_volume_path = get_volume_path("./src")?;
+        let tests_volume_path = get_volume_path("./tests")?;
+        assert_eq!(src_volume_path, tests_volume_path);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_get_volume_guid() -> io::Result<()> {
         let volume_path = get_volume_path(".")?;
 

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -1,0 +1,138 @@
+#![cfg(windows)]
+
+use reflink_copy::{check_reflink_support, reflink, reflink_or_copy, ReflinkSupport};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const FILE_SIZE: usize = 256 * 1024;
+const FILENAME: &str = "test_file.dat";
+
+// paths are defined in build.yml
+
+fn temp_dir() -> PathBuf {
+    PathBuf::from(std::env::var("RUNNER_TEMP").expect("RUNNER_TEMP is not set"))
+}
+fn refs1_dir() -> PathBuf {
+    temp_dir().join("dev-drives").join("refs1")
+}
+fn refs2_dir() -> PathBuf {
+    temp_dir().join("dev-drives").join("refs2")
+}
+fn ntfs_dir() -> PathBuf {
+    temp_dir().join("dev-drives").join("ntfs")
+}
+
+fn make_subfolder(folder: &Path, line: u32) -> std::io::Result<PathBuf> {
+    let subfolder = folder.join(format!("subfolder_{line}"));
+    std::fs::create_dir_all(&subfolder)?;
+    Ok(subfolder)
+}
+
+fn create_test_file(path: &Path) -> std::io::Result<()> {
+    if let Some(folder) = path.parent() {
+        std::fs::create_dir_all(folder)?;
+    }
+
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(&vec![0u8; FILE_SIZE])?;
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_correct_deployment() {
+    assert!(temp_dir().join("dev-drives").join("ntfs.vhdx").exists());
+}
+
+#[test]
+#[ignore]
+fn test_reflink_support_refs1_to_refs2() -> std::io::Result<()> {
+    let result = check_reflink_support(refs1_dir(), refs2_dir())?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs2_dir(), line!())?;
+    let result = check_reflink_support(from, to)?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_support_ntfs_to_refs1() -> std::io::Result<()> {
+    let result = check_reflink_support(ntfs_dir(), refs1_dir())?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+
+    let from = make_subfolder(&ntfs_dir(), line!())?;
+    let to = make_subfolder(&refs1_dir(), line!())?;
+    let result = check_reflink_support(from, to)?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_support_refs1_to_ntfs() -> std::io::Result<()> {
+    let result = check_reflink_support(refs1_dir(), ntfs_dir())?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&ntfs_dir(), line!())?;
+    let result = check_reflink_support(from, to)?;
+    assert_eq!(result, ReflinkSupport::NotSupported);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_support_refs1() -> std::io::Result<()> {
+    let result = check_reflink_support(refs1_dir(), refs1_dir())?;
+    assert_eq!(result, ReflinkSupport::Supported);
+
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs1_dir(), line!())?;
+    let result = check_reflink_support(from, to)?;
+    assert_eq!(result, ReflinkSupport::Supported);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_on_supported_config() -> std::io::Result<()> {
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs1_dir(), line!())?;
+    create_test_file(&from.join(FILENAME))?;
+    reflink(from.join(FILENAME), to.join(FILENAME))
+}
+
+#[test]
+#[ignore]
+fn test_reflink_on_unsupported_config() -> std::io::Result<()> {
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs2_dir(), line!())?;
+    create_test_file(&from.join(FILENAME))?;
+    let _ = reflink(from.join(FILENAME), to.join(FILENAME)).unwrap_err();
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_or_copy_on_supported_config() -> std::io::Result<()> {
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs1_dir(), line!())?;
+    create_test_file(&from.join(FILENAME))?;
+    let result = reflink_or_copy(from.join(FILENAME), to.join(FILENAME))?;
+    assert_eq!(result, None);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reflink_or_copy_on_unsupported_config() -> std::io::Result<()> {
+    let from = make_subfolder(&refs1_dir(), line!())?;
+    let to = make_subfolder(&refs2_dir(), line!())?;
+    create_test_file(&from.join(FILENAME))?;
+    let result = reflink_or_copy(from.join(FILENAME), to.join(FILENAME))?;
+    assert_eq!(result, Some(FILE_SIZE as u64));
+    Ok(())
+}


### PR DESCRIPTION
This PR addresses issue #80 and implements `check_reflink_support` for Windows. For all other platforms, the function returns `Ok(ReflinkSupport::Unknown)`.

@NobodyXu, as promised, here's the reference implementation for Windows 😉. It would be awesome if you could review it and implement the same for Linux. Thanks!
