### PR TITLE
Add reflink_block function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       uses: samypr100/setup-dev-drive@v3
       with:
-        drive-size: 1GB
+        drive-size: 16GB
         drive-format: ReFS
         drive-type: Dynamic
         drive-path: "${{ runner.temp }}/dev-drives/refs2.vhdx"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,14 @@ jobs:
     - name: Test
       if: "! matrix.use-cross"
       run: cargo test --target ${{ matrix.target }} -- --ignored
+      env:
+        RUST_BACKTRACE: 1
 
     - name: Test using cross
       if: "matrix.use-cross"
       run: cross test --target ${{ matrix.target }} -- --ignored
+      env:
+        RUST_BACKTRACE: 1
 
   cross-check:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,13 +94,13 @@ jobs:
 
     - name: Test
       if: "! matrix.use-cross"
-      run: cargo test --target ${{ matrix.target }} -- --ignored
+      run: cargo test --target ${{ matrix.target }} -- --ignored --show-output
       env:
         RUST_BACKTRACE: 1
 
     - name: Test using cross
       if: "matrix.use-cross"
-      run: cross test --target ${{ matrix.target }} -- --ignored
+      run: cross test --target ${{ matrix.target }} -- --ignored --show-output
       env:
         RUST_BACKTRACE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,13 +94,13 @@ jobs:
 
     - name: Test
       if: "! matrix.use-cross"
-      run: cargo test --target ${{ matrix.target }} -- --ignored --show-output
+      run: cargo test --target ${{ matrix.target }} -- --include-ignored --show-output
       env:
         RUST_BACKTRACE: 1
 
     - name: Test using cross
       if: "matrix.use-cross"
-      run: cross test --target ${{ matrix.target }} -- --ignored --show-output
+      run: cross test --target ${{ matrix.target }} -- --include-ignored --show-output
       env:
         RUST_BACKTRACE: 1
 

--- a/examples/reflink_block.rs
+++ b/examples/reflink_block.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::num::NonZeroU64;
 
 fn main() -> std::io::Result<()> {
     let args: Vec<_> = std::env::args().collect();
@@ -19,7 +20,16 @@ fn main() -> std::io::Result<()> {
     let mut offset = 0u64;
     while offset < len as u64 {
         println!("reflink {offset}, {cluster_size}");
-        reflink_copy::reflink_block(&from_file, offset, &to_file, offset, cluster_size)?;
+        reflink_copy::ReflinkBlockBuilder::default()
+            .from(&from_file)
+            .from_offset(offset)
+            .to(&to_file)
+            .to_offset(offset)
+            .src_length(NonZeroU64::new(cluster_size).unwrap())
+            .cluster_size(NonZeroU64::new(cluster_size).unwrap())
+            .reflink_block()?;
+
+        //reflink_block(&from_file, offset, &to_file, offset, cluster_size)?;
         offset += cluster_size;
     }
     Ok(())

--- a/examples/reflink_block.rs
+++ b/examples/reflink_block.rs
@@ -1,19 +1,20 @@
 use std::fs::File;
 use std::num::NonZeroU64;
 
+// cargo run --example reflink_block V:/file.bin V:/file_cow.bin 4096
+
 fn main() -> std::io::Result<()> {
     let args: Vec<_> = std::env::args().collect();
-    if args.len() < 4 {
+
+    let [_, src_file, tgt_file, cluster_size] = &args[..] else {
         eprintln!(
             "Usage: {} <source_file> <target_file> <cluster_size>",
             args[0]
         );
         return Ok(());
-    }
-    let src_file = &args[1];
-    let tgt_file = &args[2];
-    let cluster_size =
-        NonZeroU64::new(args[3].parse().expect("cannot parse cluster size")).unwrap();
+    };
+    let cluster_size: NonZeroU64 = cluster_size.parse().expect("cannot parse cluster size");
+
     let from_file = File::open(src_file)?;
     let len = from_file.metadata()?.len();
     let to_file = File::create(tgt_file)?;

--- a/examples/reflink_block.rs
+++ b/examples/reflink_block.rs
@@ -1,0 +1,26 @@
+use std::fs::File;
+
+fn main() -> std::io::Result<()> {
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 4 {
+        eprintln!(
+            "Usage: {} <source_file> <target_file> <cluster_size>",
+            args[0]
+        );
+        return Ok(());
+    }
+    let src_file = &args[1];
+    let tgt_file = &args[2];
+    let cluster_size: u64 = args[3].parse().expect("cannot parse cluster size");
+    let from_file = File::open(src_file)?;
+    let len = from_file.metadata()?.len();
+    let to_file = File::create(tgt_file)?;
+    to_file.set_len(len)?;
+    let mut offset = 0u64;
+    while offset < len as u64 {
+        println!("reflink {offset}, {cluster_size}");
+        reflink_copy::reflink_block(&from_file, offset, &to_file, offset, cluster_size)?;
+        offset += cluster_size;
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub enum ReflinkSupport {
 pub fn reflink_block(
     from: &fs::File,
     from_offset: u64,
-    to: &mut fs::File,
+    to: &fs::File,
     to_offset: u64,
     block_size: u64,
 ) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ pub enum ReflinkSupport {
 
 /// Creates a reflink of a specified block from one file to another.
 ///
-/// This function is designed to be high performant and does not perform any extra API calls.
+/// This function is designed to be highly performant and does not perform any extra API calls.
 /// It is expected that the user takes care of necessary preliminary checks and preparations.
 ///
 /// If you need to clone an entire file, consider using the [`reflink`] or [`reflink_or_copy`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,3 +187,17 @@ pub enum ReflinkSupport {
     /// Reflink support is unconfirmed.
     Unknown,
 }
+
+#[cfg_attr(not(windows), allow(unused_variables))]
+pub fn reflink_block(
+    from: &fs::File,
+    from_offset: u64,
+    to: &mut fs::File,
+    to_offset: u64,
+    block_size: u64,
+) -> io::Result<()> {
+    #[cfg(windows)]
+    return sys::reflink_block(from, from_offset, to, to_offset, block_size);
+    #[cfg(not(windows))]
+    Err(io::Error::other("Not implemented"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,8 @@ pub enum ReflinkSupport {
 /// - The source and destination regions must begin and end at a cluster boundary.
 /// - The cloned region must be less than 4GB in length.
 /// - The destination region must not extend past the end of file. If the application wishes to
-///   extend the destination with cloned data, it must first call SetEndOfFile.
+///   extend the destination with cloned data, it must first call
+///   [`File::set_len`](fn@std::fs::File::set_len).
 /// - If the source and destination regions are in the same file, they must not overlap. (The
 ///   application may able to proceed by splitting up the block clone operation into multiple block
 ///   clones that no longer overlap.)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,59 @@ pub enum ReflinkSupport {
     Unknown,
 }
 
+/// Creates a reflink of a specified block from one file to another.
+///
+/// This function is designed to be high performant and does not perform any extra API calls.
+/// It is expected that the user takes care of necessary preliminary checks and preparations.
+///
+/// If you need to clone an entire file, consider using the [`reflink`] or [`reflink_or_copy`]
+/// functions instead.
+///
+/// > Note: Currently the function works only for windows. It returns `Err` for any other platform.
+///
+/// # Windows Restrictions and Remarks
+/// - The source and destination regions must begin and end at a cluster boundary.
+/// - The cloned region must be less than 4GB in length.
+/// - The destination region must not extend past the end of file. If the application wishes to
+///   extend the destination with cloned data, it must first call SetEndOfFile.
+/// - If the source and destination regions are in the same file, they must not overlap. (The
+///   application may able to proceed by splitting up the block clone operation into multiple block
+///   clones that no longer overlap.)
+/// - The source and destination files must be on the same ReFS volume.
+/// - The source and destination files must have the same Integrity Streams setting (that is,
+///   Integrity Streams must be enabled in both files, or disabled in both files).
+/// - If the source file is sparse, the destination file must also be sparse.
+/// - The block clone operation will break Shared Opportunistic Locks (also known as Level 2
+///   Opportunistic Locks).
+/// - The ReFS volume must have been formatted with Windows Server 2016, and if Windows Failover
+///   Clustering is in use, the Clustering Functional Level must have been Windows Server 2016 or
+///   later at format time.
+///
+/// More information can be found by the
+/// [link](https://learn.microsoft.com/en-us/windows/win32/fileio/block-cloning).
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::fs::File;
+///
+/// fn main() -> std::io::Result<()> {
+///     const CLUSTER_SIZE: u64 = 4096;
+///     let from_file = File::open("source.txt")?;
+///     let len = from_file.metadata()?.len();
+///     let to_file = File::create("destination.txt")?;
+///     to_file.set_len(len)?;
+///     let mut offset = 0u64;
+///     while offset < len {
+///         reflink_copy::reflink_block(&from_file, offset, &to_file, offset, CLUSTER_SIZE)?;
+///         offset += CLUSTER_SIZE;
+///     }
+///     if offset > len {
+///         to_file.set_len(len)?;
+///     }
+///     Ok(())
+/// }
+/// ```
 #[cfg_attr(not(windows), allow(unused_variables))]
 pub fn reflink_block(
     from: &fs::File,

--- a/src/reflink_block.rs
+++ b/src/reflink_block.rs
@@ -13,14 +13,16 @@ use std::num::NonZeroU64;
 ///
 /// > Note: Currently the function works only for windows. It returns `Err` for any other platform.
 ///
-/// # Windows Restrictions and Remarks
+/// # General restrictions
 /// - The source and destination regions must begin and end at a cluster boundary.
-/// - The destination region must not extend past the end of file. If the application wishes to
-///   extend the destination with cloned data, it must first call
-///   [`File::set_len`](fn@std::fs::File::set_len).
 /// - If the source and destination regions are in the same file, they must not overlap. (The
 ///   application may able to proceed by splitting up the block clone operation into multiple block
 ///   clones that no longer overlap.)
+///
+/// # Windows specific restrictions and remarks
+/// - The destination region must not extend past the end of file. If the application wishes to
+///   extend the destination with cloned data, it must first call
+///   [`File::set_len`](fn@std::fs::File::set_len).
 /// - The source and destination files must be on the same ReFS volume.
 /// - The source and destination files must have the same Integrity Streams setting (that is,
 ///   Integrity Streams must be enabled in both files, or disabled in both files).
@@ -30,10 +32,13 @@ use std::num::NonZeroU64;
 /// - The ReFS volume must have been formatted with Windows Server 2016, and if Windows Failover
 ///   Clustering is in use, the Clustering Functional Level must have been Windows Server 2016 or
 ///   later at format time.
-/// - Note: If block is 4GB or larger, [`ReflinkBlockBuilder::reflink_block`] splits it to multiple
-///   smaller blocks with the size of 4GB minus cluster size.
 ///
-/// More information can be found by the
+/// > Note: In order to handle blocks larger than 4GB,
+///   [`ReflinkBlockBuilder::reflink_block`] splits these big blocks into smaller ones.
+///   Each smaller block is 4GB minus the cluster size. This means there might be more than one API
+///   call needed for the larger blocks.
+///
+/// More information about block cloning on Windows can be found by the
 /// [link](https://learn.microsoft.com/en-us/windows/win32/fileio/block-cloning).
 ///
 /// # Examples

--- a/src/reflink_block.rs
+++ b/src/reflink_block.rs
@@ -1,0 +1,146 @@
+use crate::sys;
+use std::fs::File;
+use std::io;
+use std::num::NonZeroU64;
+
+/// Creates a reflink of a specified block from one file to another.
+///
+/// This functionality is designed to be highly performant and does not perform any extra API calls.
+/// It is expected that the user takes care of necessary preliminary checks and preparations.
+///
+/// If you need to clone an entire file, consider using the [`reflink`] or [`reflink_or_copy`]
+/// functions instead.
+///
+/// > Note: Currently the function works only for windows. It returns `Err` for any other platform.
+///
+/// # Windows Restrictions and Remarks
+/// - The source and destination regions must begin and end at a cluster boundary.
+/// - The destination region must not extend past the end of file. If the application wishes to
+///   extend the destination with cloned data, it must first call
+///   [`File::set_len`](fn@std::fs::File::set_len).
+/// - If the source and destination regions are in the same file, they must not overlap. (The
+///   application may able to proceed by splitting up the block clone operation into multiple block
+///   clones that no longer overlap.)
+/// - The source and destination files must be on the same ReFS volume.
+/// - The source and destination files must have the same Integrity Streams setting (that is,
+///   Integrity Streams must be enabled in both files, or disabled in both files).
+/// - If the source file is sparse, the destination file must also be sparse.
+/// - The block clone operation will break Shared Opportunistic Locks (also known as Level 2
+///   Opportunistic Locks).
+/// - The ReFS volume must have been formatted with Windows Server 2016, and if Windows Failover
+///   Clustering is in use, the Clustering Functional Level must have been Windows Server 2016 or
+///   later at format time.
+/// - Note: If block is 4GB or larger, [`ReflinkBlockBuilder::reflink_block`] splits it to multiple
+///   smaller blocks with the size of 4GB minus cluster size.
+///
+/// More information can be found by the
+/// [link](https://learn.microsoft.com/en-us/windows/win32/fileio/block-cloning).
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::fs::File;
+/// use std::num::NonZeroU64;
+///
+/// fn main() -> std::io::Result<()> {
+///     const CLUSTER_SIZE: u64 = 4096;
+///     let from_file = File::open("source.txt")?;
+///     let len = from_file.metadata()?.len();
+///     let to_file = File::create("destination.txt")?;
+///     to_file.set_len(len)?;
+///     let mut offset = 0u64;
+///     while offset < len {
+///         reflink_copy::ReflinkBlockBuilder::new()
+///             .from(&from_file)
+///             .from_offset(offset)
+///             .to(&to_file)
+///             .to_offset(offset)
+///             .src_length(NonZeroU64::new(CLUSTER_SIZE).unwrap())
+///             .cluster_size(NonZeroU64::new(CLUSTER_SIZE).unwrap())
+///             .reflink_block()?;
+///         offset += CLUSTER_SIZE;
+///     }
+///     Ok(())
+/// }
+/// ```
+/// [`reflink`]: crate::reflink
+/// [`reflink_or_copy`]: crate::reflink_or_copy
+#[derive(Debug, Default)]
+pub struct ReflinkBlockBuilder<'from, 'to> {
+    from: Option<&'from File>,
+    from_offset: u64,
+    to: Option<&'to File>,
+    to_offset: u64,
+    src_length: u64,
+    cluster_size: Option<NonZeroU64>,
+}
+
+impl<'from, 'to> ReflinkBlockBuilder<'from, 'to> {
+    /// Creates a new instance of [`ReflinkBlockBuilder`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the source file.
+    #[must_use]
+    pub fn from(mut self, from: &'from File) -> ReflinkBlockBuilder<'from, 'to> {
+        self.from = Some(from);
+        self
+    }
+
+    /// Sets the offset within the source file.
+    #[must_use]
+    pub fn from_offset(mut self, from_offset: u64) -> Self {
+        self.from_offset = from_offset;
+        self
+    }
+
+    /// Sets the destination file.
+    #[must_use]
+    pub fn to(mut self, to: &'to File) -> ReflinkBlockBuilder<'from, 'to> {
+        self.to = Some(to);
+        self
+    }
+
+    /// Sets the offset within the destination file.
+    #[must_use]
+    pub fn to_offset(mut self, to_offset: u64) -> Self {
+        self.to_offset = to_offset;
+        self
+    }
+
+    /// Sets the length of the source data to be reflinked.
+    #[must_use]
+    pub fn src_length(mut self, src_length: NonZeroU64) -> Self {
+        self.src_length = src_length.get();
+        self
+    }
+
+    /// Sets the cluster size. It is used to calculate the max block size of a single reflink call
+    /// on Windows.
+    #[must_use]
+    pub fn cluster_size(mut self, cluster_size: NonZeroU64) -> Self {
+        self.cluster_size = Some(cluster_size);
+        self
+    }
+
+    /// Performs reflink operation for the specified block of data.
+    #[cfg_attr(not(windows), allow(unused_variables))]
+    pub fn reflink_block(self) -> io::Result<()> {
+        assert!(self.from.is_some(), "`from` is not set");
+        assert!(self.to.is_some(), "`to` is not set");
+        assert_ne!(self.src_length, 0, "`src_length` is not set");
+
+        #[cfg(windows)]
+        return sys::reflink_block(
+            self.from.unwrap(),
+            self.from_offset,
+            self.to.unwrap(),
+            self.to_offset,
+            self.src_length,
+            self.cluster_size,
+        );
+        #[cfg(not(windows))]
+        Err(io::Error::other("Not implemented"))
+    }
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -12,7 +12,7 @@ cfg_if! {
         mod windows_impl;
         pub use self::windows_impl::reflink;
         pub use self::windows_impl::check_reflink_support;
-        pub use self::windows_impl::reflink_block;
+        pub(crate) use self::windows_impl::reflink_block;
     } else {
         pub use self::reflink_not_supported as reflink;
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -12,6 +12,7 @@ cfg_if! {
         mod windows_impl;
         pub use self::windows_impl::reflink;
         pub use self::windows_impl::check_reflink_support;
+        pub use self::windows_impl::reflink_block;
     } else {
         pub use self::reflink_not_supported as reflink;
     }

--- a/src/sys/utility.rs
+++ b/src/sys/utility.rs
@@ -39,10 +39,6 @@ impl AutoRemovedFile {
     pub fn as_inner_file(&self) -> &File {
         self.inner.as_ref().unwrap()
     }
-
-    pub fn as_inner_file_mut(&mut self) -> &mut File {
-        self.inner.as_mut().unwrap()
-    }
 }
 
 #[cfg(unix)]

--- a/src/sys/utility.rs
+++ b/src/sys/utility.rs
@@ -39,6 +39,10 @@ impl AutoRemovedFile {
     pub fn as_inner_file(&self) -> &File {
         self.inner.as_ref().unwrap()
     }
+
+    pub fn as_inner_file_mut(&mut self) -> &mut File {
+        self.inner.as_mut().unwrap()
+    }
 }
 
 #[cfg(unix)]

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -40,7 +40,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
         (FILE_FLAGS_AND_ATTRIBUTES(src_metadata.file_attributes()) & FILE_ATTRIBUTE_SPARSE_FILE).0
             != 0;
 
-    let mut dest = AutoRemovedFile::create_new(to)?;
+    let dest = AutoRemovedFile::create_new(to)?;
 
     // Set the destination to be sparse while we clone.
     // Important to avoid allocating zero-backed real storage when cloning
@@ -107,7 +107,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
         reflink_block(
             &src,
             bytes_copied as u64,
-            dest.as_inner_file_mut(),
+            dest.as_inner_file(),
             bytes_copied as u64,
             bytes_to_copy as u64,
         )?;
@@ -367,7 +367,7 @@ fn get_volume_flags(volume_path_w: &[u16]) -> io::Result<u32> {
 pub fn reflink_block(
     from: &File,
     from_offset: u64,
-    to: &mut File,
+    to: &File,
     to_offset: u64,
     block_size: u64,
 ) -> io::Result<()> {

--- a/src/sys/windows_impl.rs
+++ b/src/sys/windows_impl.rs
@@ -399,6 +399,30 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_round_up() {
+        assert_eq!(round_up(0, 2), 0);
+        assert_eq!(round_up(1, 2), 2);
+        assert_eq!(round_up(2, 2), 2);
+
+        assert_eq!(round_up(15, 8), 16);
+        assert_eq!(round_up(17, 8), 24);
+
+        assert_eq!(round_up(100000, 4096), 102400);
+        assert_eq!(round_up(100000, 65536), 131072);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_multiple_zero() {
+        round_up(10, 0);
+    }
+    #[test]
+    #[should_panic]
+    fn test_invalid_multiple_non_power_of_two() {
+        round_up(10, 3);
+    }
+
+    #[test]
     fn test_get_volume_path_is_same() -> io::Result<()> {
         let src_volume_path = get_volume_path("./src")?;
         let tests_volume_path = get_volume_path("./tests")?;

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -1,9 +1,8 @@
 #![cfg(windows)]
 
-use reflink_copy::{
-    check_reflink_support, reflink, reflink_block, reflink_or_copy, ReflinkSupport,
-};
+use reflink_copy::{check_reflink_support, reflink, reflink_or_copy, ReflinkSupport};
 use std::io::{Read, Write};
+use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 
 const FILE_SIZE: usize = 256 * 1024;
@@ -23,6 +22,22 @@ fn refs2_dir() -> PathBuf {
 }
 fn ntfs_dir() -> PathBuf {
     temp_dir().join("dev-drives").join("ntfs")
+}
+
+fn reflink_block(
+    from: &std::fs::File,
+    from_offset: u64,
+    to: &std::fs::File,
+    to_offset: u64,
+    src_length: u64,
+) -> std::io::Result<()> {
+    reflink_copy::ReflinkBlockBuilder::default()
+        .from(from)
+        .from_offset(from_offset)
+        .to(to)
+        .to_offset(to_offset)
+        .src_length(NonZeroU64::new(src_length).unwrap())
+        .reflink_block()
 }
 
 fn make_subfolder(folder: &Path, line: u32) -> std::io::Result<PathBuf> {

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -31,12 +31,9 @@ fn reflink_block(
     to_offset: u64,
     src_length: u64,
 ) -> std::io::Result<()> {
-    reflink_copy::ReflinkBlockBuilder::default()
-        .from(from)
+    reflink_copy::ReflinkBlockBuilder::new(from, to, NonZeroU64::new(src_length).unwrap())
         .from_offset(from_offset)
-        .to(to)
         .to_offset(to_offset)
-        .src_length(NonZeroU64::new(src_length).unwrap())
         .reflink_block()
 }
 

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -212,7 +212,11 @@ fn test_reflink_block_reverse() -> std::io::Result<()> {
         let r = num_clusters - 1 - i;
         let from_offset = i * CLUSTER_SIZE;
         let to_offset = r * CLUSTER_SIZE;
-        println!("reflink {}{from_offset} -> {}{to_offset}, block {CLUSTER_SIZE}", from.display(), to.display());
+        println!(
+            "reflink {}{from_offset} -> {}{to_offset}, block {CLUSTER_SIZE}",
+            from.display(),
+            to.display()
+        );
         reflink_block(
             &source_file,
             from_offset as u64,

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -213,7 +213,7 @@ fn test_reflink_block_reverse() -> std::io::Result<()> {
         let from_offset = i * CLUSTER_SIZE;
         let to_offset = r * CLUSTER_SIZE;
         println!(
-            "reflink {}{from_offset} -> {}{to_offset}, block {CLUSTER_SIZE}",
+            "reflink {}:{from_offset} -> {}:{to_offset}, block {CLUSTER_SIZE}",
             from.display(),
             to.display()
         );

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -184,12 +184,11 @@ fn test_reflink_block_whole_file() -> std::io::Result<()> {
     Ok(())
 }
 
-
 #[test]
 #[ignore]
 fn test_reflink_unaligned_file() -> std::io::Result<()> {
     let num_clusters = 3;
-    let data_size = CLUSTER_SIZE * num_clusters + 1;
+    let data_size = (CLUSTER_SIZE * num_clusters + 1) as u64;
 
     let from = make_subfolder(&refs2_dir(), line!())?.join(FILENAME);
     let to = make_subfolder(&refs2_dir(), line!())?.join(FILENAME);
@@ -202,13 +201,16 @@ fn test_reflink_unaligned_file() -> std::io::Result<()> {
     source_file.write_all(&data)?;
     source_file.write("+".as_bytes())?;
     source_file.flush()?;
-    assert_eq!(source_file.metadata()?.len(), data_size as u64);
+    assert_eq!(source_file.metadata()?.len(), data_size);
 
     let mut dest_file = std::fs::File::create_new(&to)?;
-
-    dest_file.set_len(data_size as u64)?;
-    reflink_block(&source_file, 0, &dest_file, 0, data_size as u64)?;
-
+    dest_file.set_len(data_size)?;
+    println!(
+        "reflink {}:0 -> {}:0, block {data_size}",
+        from.display(),
+        to.display()
+    );
+    reflink_block(&source_file, 0, &dest_file, 0, data_size)?;
     dest_file.flush()?;
     drop(source_file);
     drop(dest_file);

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -236,7 +236,7 @@ fn test_reflink_source_file() -> std::io::Result<()> {
     source_file.flush()?;
     assert_eq!(source_file.metadata()?.len(), data_size);
 
-    source_file.set_len(data_size*2)?;
+    source_file.set_len(data_size * 2)?;
     println!(
         "reflink {}:0 -> {}:{data_size}, block {data_size}",
         from.display(),
@@ -244,12 +244,12 @@ fn test_reflink_source_file() -> std::io::Result<()> {
     );
     reflink_block(&source_file, 0, &source_file, data_size, data_size)?;
     source_file.flush()?;
-    assert_eq!(source_file.metadata()?.len(), data_size*2);
+    assert_eq!(source_file.metadata()?.len(), data_size * 2);
     drop(source_file);
 
     let mut file = std::fs::File::open(from)?;
     let mut buffer1 = vec![0u8; data_size as usize];
-    let mut buffer2 = vec![0u8; data_size as usize];;
+    let mut buffer2 = vec![0u8; data_size as usize];
     file.read_exact(buffer1.as_mut_slice())?;
     file.read_exact(buffer2.as_mut_slice())?;
     assert_eq!(buffer1, buffer2);

--- a/tests/reflink_win.rs
+++ b/tests/reflink_win.rs
@@ -189,6 +189,7 @@ fn test_reflink_block_whole_file() -> std::io::Result<()> {
 fn test_reflink_unaligned_file() -> std::io::Result<()> {
     let num_clusters = 3;
     let data_size = (CLUSTER_SIZE * num_clusters + 1) as u64;
+    let aligned_data_size = (CLUSTER_SIZE * num_clusters + CLUSTER_SIZE) as u64;
 
     let from = make_subfolder(&refs2_dir(), line!())?.join(FILENAME);
     let to = make_subfolder(&refs2_dir(), line!())?.join(FILENAME);
@@ -210,7 +211,7 @@ fn test_reflink_unaligned_file() -> std::io::Result<()> {
         from.display(),
         to.display()
     );
-    reflink_block(&source_file, 0, &dest_file, 0, data_size)?;
+    reflink_block(&source_file, 0, &dest_file, 0, aligned_data_size)?;
     dest_file.flush()?;
     drop(source_file);
     drop(dest_file);


### PR DESCRIPTION
Adding block-level reflink capabilities allows for more granular and efficient data management. This can be particularly beneficial for applications that need to clone or deduplicate specific segments of large files.

Details:
- PR replaces `--ignored` with `--include-ignored` for cargo test to enable all tests
- it includes only windows implementation of `reflink_block`, although it should be possible to add linux support in the future without changing function signature
- `reflink_block` accepts immutable reference to target file to allow calling this function on the same file

issue: #80 