### PR TITLE
Implement reflink_block for lunix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -92,6 +92,7 @@ name = "reflink-copy"
 version = "0.1.22"
 dependencies = [
  "cfg-if",
+ "libc",
  "regex",
  "rustix",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ version = "0.38.20"
 default-features = false
 features = ["fs", "std"]
 
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies.libc]
+version = "0.2.169"
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.59.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Ioctl", "Win32_System_IO", "Win32_System_SystemServices"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.38.20"
 default-features = false
 features = ["fs", "std"]
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies.libc]
+[target.'cfg(target_os = "linux")'.dependencies.libc]
 version = "0.2.169"
 
 [target.'cfg(windows)'.dependencies]

--- a/examples/reflink_block.rs
+++ b/examples/reflink_block.rs
@@ -21,15 +21,13 @@ fn main() -> std::io::Result<()> {
     to_file.set_len(len)?;
 
     let mut offset = 0u64;
-    while offset < len as u64 {
-        let remaining = len - offset;
-
+    while offset < len {
         // Windows API clones the entire cluster regardless of the number of bytes actually used by
         // the file in that cluster.
         #[cfg(windows)]
         let src_length = cluster_size;
         #[cfg(not(windows))]
-        let src_length = NonZeroU64::new(cluster_size.get().min(remaining)).unwrap();
+        let src_length = NonZeroU64::new(cluster_size.get().min(len - offset)).unwrap();
 
         println!("reflink {offset}, {src_length}");
         reflink_copy::ReflinkBlockBuilder::new(&from_file, &to_file, src_length)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub fn reflink_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Resu
 ///     Ok(())
 /// }
 /// ```
+#[cfg_attr(not(windows), allow(unused_variables))]
 pub fn check_reflink_support(
     from: impl AsRef<Path>,
     to: impl AsRef<Path>,

--- a/src/reflink_block.rs
+++ b/src/reflink_block.rs
@@ -117,18 +117,14 @@ impl<'from, 'to> ReflinkBlockBuilder<'from, 'to> {
     }
 
     /// Performs reflink operation for the specified block of data.
-    #[cfg_attr(not(windows), allow(unused_variables))]
     pub fn reflink_block(self) -> io::Result<()> {
-        #[cfg(windows)]
-        return sys::reflink_block(
+        sys::reflink_block(
             self.from,
             self.from_offset,
             self.to,
             self.to_offset,
             self.src_length,
             self.cluster_size,
-        );
-        #[cfg(not(windows))]
-        Err(io::Error::other("Not implemented"))
+        )
     }
 }

--- a/src/reflink_block.rs
+++ b/src/reflink_block.rs
@@ -11,15 +11,28 @@ use std::num::NonZeroU64;
 /// If you need to clone an entire file, consider using the [`reflink`] or [`reflink_or_copy`]
 /// functions instead.
 ///
-/// > Note: Currently the function works only for windows. It returns `Err` for any other platform.
+/// > Note: Currently the function works only for windows and linux platforms. It returns `Err` for
+///   any other platform.
 ///
 /// # General restrictions
+///
 /// - The source and destination regions must begin and end at a cluster boundary.
 /// - If the source and destination regions are in the same file, they must not overlap. (The
 ///   application may able to proceed by splitting up the block clone operation into multiple block
 ///   clones that no longer overlap.)
+/// - `src_length` equal to 0 is not supported.
+///
+/// # Linux specific restrictions and remarks
+///
+/// - If the file size is not aligned to the cluster size, the reflink operation must not exceed
+///   the file length. For example, to reflink the whole file with size of 7000 bytes, `src_length`
+///   should be 7000 bytes.
+///
+/// More information about block cloning on Linux can be found by the
+/// [link](https://www.man7.org/linux/man-pages/man2/ioctl_ficlonerange.2.html).
 ///
 /// # Windows specific restrictions and remarks
+///
 /// - The destination region must not extend past the end of file. If the application wishes to
 ///   extend the destination with cloned data, it must first call
 ///   [`File::set_len`](fn@std::fs::File::set_len).
@@ -32,6 +45,9 @@ use std::num::NonZeroU64;
 /// - The ReFS volume must have been formatted with Windows Server 2016, and if Windows Failover
 ///   Clustering is in use, the Clustering Functional Level must have been Windows Server 2016 or
 ///   later at format time.
+/// - If the file size is not aligned to the cluster size, the reflink operation should still
+///   be aligned by the cluster size. For example, to reflink the whole file with size of 7000 bytes
+///   and a cluster size of 4096 bytes, `src_length` should be 8192 bytes.
 ///
 /// > Note: In order to handle blocks larger than 4GB,
 ///   [`ReflinkBlockBuilder::reflink_block`] splits these big blocks into smaller ones.

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::{fs, io};
 
 use cfg_if::cfg_if;
 
@@ -8,6 +9,7 @@ cfg_if! {
     if #[cfg(unix)] {
         mod unix;
         pub use self::unix::reflink;
+        pub(crate) use self::reflink_block;
     } else if #[cfg(windows)] {
         mod windows_impl;
         pub use self::windows_impl::reflink;
@@ -15,10 +17,22 @@ cfg_if! {
         pub(crate) use self::windows_impl::reflink_block;
     } else {
         pub use self::reflink_not_supported as reflink;
+        pub(crate) use self::reflink_block_not_supported as reflink_block;
     }
 }
 
 #[allow(dead_code)]
 pub fn reflink_not_supported(_from: &Path, _to: &Path) -> std::io::Result<()> {
+    Err(std::io::ErrorKind::Unsupported.into())
+}
+
+pub(crate) fn reflink_block_not_supported(
+    _from: &fs::File,
+    _from_offset: u64,
+    _to: &fs::File,
+    _to_offset: u64,
+    _src_length: u64,
+    _cluster_size: Option<std::num::NonZeroU64>,
+) -> io::Result<()> {
     Err(std::io::ErrorKind::Unsupported.into())
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -26,6 +26,7 @@ pub fn reflink_not_supported(_from: &Path, _to: &Path) -> std::io::Result<()> {
     Err(std::io::ErrorKind::Unsupported.into())
 }
 
+#[allow(dead_code)]
 pub(crate) fn reflink_block_not_supported(
     _from: &fs::File,
     _from_offset: u64,

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -9,7 +9,7 @@ cfg_if! {
     if #[cfg(unix)] {
         mod unix;
         pub use self::unix::reflink;
-        pub(crate) use self::reflink_block;
+        pub(crate) use self::unix::reflink_block;
     } else if #[cfg(windows)] {
         mod windows_impl;
         pub use self::windows_impl::reflink;

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -1,3 +1,4 @@
+use std::os::unix::io::AsRawFd;
 use std::{fs, io, path::Path};
 
 use crate::sys::utility::AutoRemovedFile;
@@ -11,4 +12,32 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
 
     dest.persist();
     Ok(())
+}
+
+pub(crate) fn reflink_block(
+    from: &fs::File,
+    from_offset: u64,
+    to: &fs::File,
+    to_offset: u64,
+    src_length: u64,
+    _cluster_size: Option<std::num::NonZeroU64>,
+) -> io::Result<()> {
+    let ret = unsafe {
+        libc::ioctl(
+            to.as_raw_fd(),
+            libc::FICLONE,
+            &libc::ficlone_range {
+                src_fd: from.as_raw_fd(),
+                src_offset: from_offset,
+                src_length,
+                dest_offset: to_offset,
+            },
+        )
+    };
+
+    if ret == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -25,7 +25,7 @@ pub(crate) fn reflink_block(
     let ret = unsafe {
         libc::ioctl(
             to.as_raw_fd(),
-            libc::FICLONE,
+            libc::FICLONERANGE,
             &libc::file_clone_range {
                 src_fd: from.as_raw_fd().into(),
                 src_offset: from_offset,

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -26,8 +26,8 @@ pub(crate) fn reflink_block(
         libc::ioctl(
             to.as_raw_fd(),
             libc::FICLONE,
-            &libc::ficlone_range {
-                src_fd: from.as_raw_fd(),
+            &libc::file_clone_range {
+                src_fd: from.as_raw_fd().into(),
                 src_offset: from_offset,
                 src_length,
                 dest_offset: to_offset,

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -4,10 +4,13 @@ cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android"))] {
         mod linux;
         pub use linux::reflink;
+        pub(crate) use linux::reflink_block;
     } else if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))] {
         mod macos;
         pub use macos::reflink;
+        pub(crate) use super::reflink_not_supported as reflink_block;
     } else {
         pub use super::reflink_not_supported as reflink;
+        pub(crate) use super::reflink_not_supported as reflink_block;
     }
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -8,9 +8,9 @@ cfg_if! {
     } else if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))] {
         mod macos;
         pub use macos::reflink;
-        pub(crate) use super::reflink_not_supported as reflink_block;
+        pub(crate) use super::reflink_block_not_supported as reflink_block;
     } else {
         pub use super::reflink_not_supported as reflink;
-        pub(crate) use super::reflink_not_supported as reflink_block;
+        pub(crate) use super::reflink_block_not_supported as reflink_block;
     }
 }


### PR DESCRIPTION
This PR implements `reflink_block` for Linux using `FICLONERANGE` from the libc crate. libc does not provide this functionality for Android, so it's Linux only - https://docs.rs/libc/latest/src/libc/unix/linux_like/linux/arch/generic/mod.rs.html#119

This code has been tested on Ubuntu x86_64 with the Btrfs filesystem.