### PR TITLE
ci: use ubuntu-latest instead of ubuntu-20.04 in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: armv7-unknown-linux-musleabihf
-            os: ubuntu-20.04
+            os: ubuntu-latest
             use-cross: true
           - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-20.04
+            os: ubuntu-latest
             use-cross: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest


### PR DESCRIPTION
20.04 is not supported by GHA anymore