### PR TITLE
fix: exclude sparc/sparc64 from linux reflink path

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -1,7 +1,8 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "android"))] {
+    // ioctl_ficlone / FICLONERANGE are not available on SPARC platforms
+    if #[cfg(all(any(target_os = "linux", target_os = "android"), not(any(target_arch = "sparc", target_arch = "sparc64"))))] {
         mod linux;
         pub use linux::reflink;
         pub(crate) use linux::reflink_block;


### PR DESCRIPTION
`rustix::fs::ioctl_ficlone` and `libc::FICLONERANGE` are not available on SPARC platforms, causing a compile error on sparc64 Linux.

This excludes sparc/sparc64 from the Linux code path, routing them to the `reflink_not_supported` fallback instead.

Fixes #163